### PR TITLE
Fixed link target

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,15 +12,15 @@
 
     <div class="card hidden">
       <div class="card-header">
-        <p class="card-suptitle">On <a title="View on GitHub">GitHub</a></p>
-        <h1 class="card-title"><a title="View more">Loading...</a></h1>
+        <p class="card-suptitle">On <a target="_top" title="View on GitHub">GitHub</a></p>
+        <h1 class="card-title"><a target="_top" title="View more">Loading...</a></h1>
       </div>
       <div class="card-body">
         <dl class="card-details">
           <dt>Forked</dt>
-          <dd class="fork"><a title="View fork details"><!-- Fork count via javascript --></a></dd>
+          <dd class="fork"><a target="_top" title="View fork details"><!-- Fork count via javascript --></a></dd>
           <dt>Starred</dt>
-          <dd class="star"><a title="View fork details"><!-- Stargazers count via javascript --></a></dd>
+          <dd class="star"><a target="_top" title="View fork details"><!-- Stargazers count via javascript --></a></dd>
         </dl>
       </div>
     </div>


### PR DESCRIPTION
The links at the current state would open in the iframe itself, which is really inconvenient. 
`target="_top"` assures they are always targeting the topmost frame